### PR TITLE
Changes the Setup of the DbContext and its options

### DIFF
--- a/Norm/Database/Contexts/NormDbContext.cs
+++ b/Norm/Database/Contexts/NormDbContext.cs
@@ -9,17 +9,8 @@ namespace Norm.Database.Contexts
 {
     public class NormDbContext : DbContext
     {
-        public NormDbContext(IOptions<BotOptions> options, ILoggerFactory factory)
+        public NormDbContext(DbContextOptions options) : base(options)
         {
-            this.dbConnectionString = options.Value.Database.AsNpgsqlConnectionString();
-            this.loggerFactory = factory;
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseNpgsql(this.dbConnectionString, o => o.UseNodaTime())
-                .UseLoggerFactory(this.loggerFactory);
         }
 
         protected override void OnModelCreating(ModelBuilder builder)
@@ -31,7 +22,7 @@ namespace Norm.Database.Contexts
         public DbContext Context => this;
 
         private readonly string dbConnectionString;
-        public ILoggerFactory loggerFactory;
+        public ILoggerFactory loggerFactory;        
 
         // Novel Tables
         public DbSet<NovelInfo> AllNovelInfo { get; private set; }


### PR DESCRIPTION
# Fixes
#30 

# Description
The setup of all services should remain in one place as much as possible.  With this said, I have changed the setup of the DbContext to be with the rest of the services utilizing the AddDbContext extension provided by EntityFrameworkCore.  

# Changes
1) Refactored the setup that was going on in the DbContext and moved it within the AddBotServices of Program.cs